### PR TITLE
Add -p to mkdir to create intermediate directories

### DIFF
--- a/dns/blacklist2dns
+++ b/dns/blacklist2dns
@@ -93,7 +93,7 @@ create_directory () {
 			return 73
 		fi
 	else
-		mkdir "$DIRECTORY"
+		mkdir -p "$DIRECTORY"
 		RC=$?
 		if [ $RC -ne 0 ]; then
 			echo "unable to create workdir ('$DIRECTORY'): $RC" > /dev/stderr


### PR DESCRIPTION
If you set `WORKDIR` to a directory that that doesn't already exist (such as /var/tmp/blacklist), the script fails. Using `mkdir -p` creates all intermediate directories and prevents this problem.
